### PR TITLE
CarouselStack not rendering properly if its child view contains Button inside Stack views

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -27,7 +27,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"),
-        .package(url: "https://github.com/dscyrescotti/ViewInspector.git", branch: "master"),
+        .package(url: "https://github.com/nalexn/ViewInspector.git", from: "0.9.2"),
     ],
     targets: [
         .target(

--- a/Sources/Utils/PreferenceKeys/SizePreferenceKey.swift
+++ b/Sources/Utils/PreferenceKeys/SizePreferenceKey.swift
@@ -6,7 +6,5 @@ public struct SizePreferenceKey: PreferenceKey {
 
     public static var defaultValue: Value = .zero
 
-    public static func reduce(value: inout Value, nextValue: () -> Value) {
-        value = nextValue()
-    }
+    public static func reduce(value: inout Value, nextValue: () -> Value) { }
 }

--- a/Tests/ShuffleItTests/CarouselStack/CarouselStackTests.swift
+++ b/Tests/ShuffleItTests/CarouselStack/CarouselStackTests.swift
@@ -75,6 +75,31 @@ final class CarouselStackTests: BaseTestCase {
         ViewHosting.host(view: view, size: .init(width: 300, height: 800))
         self.wait(for: [exp], timeout: 0.5)
     }
+
+    func testCarouselStackStatesWithButton() throws {
+        let view = CarouselStack(colors) { color in
+            HStack {
+                Button(action: { }) {
+                    Text("Button")
+                }
+            }
+            .frame(maxWidth: .infinity)
+            .frame(height: 200)
+            .background(color)
+        }
+        let exp = view.inspection.inspect(after: 0.2) { view in
+            let sut = try view.actualView()
+            let width = 300 - sut.padding * 2
+            XCTAssertEqual(sut.index, 0)
+            XCTAssertEqual(sut.xPosition, 0)
+            XCTAssertEqual(sut.direction, .left)
+            XCTAssertEqual(sut.size, .init(width: width, height: 200))
+            XCTAssertEqual(sut.autoSliding, false)
+            XCTAssertEqual(sut.isActiveGesture, false)
+        }
+        ViewHosting.host(view: view, size: .init(width: 300, height: 800))
+        self.wait(for: [exp], timeout: 0.5)
+    }
     
     #if !os(tvOS)
     func testCarouselStackDisabled() throws {


### PR DESCRIPTION
This PR contains the bug fix for CarouselStack not rendering properly if its child view contains Button inside Stack views.