### PR TITLE
Fix initialIndex bug in second CarouselStack initializer

### DIFF
--- a/Sources/CarouselStack/View/CarouselStack.swift
+++ b/Sources/CarouselStack/View/CarouselStack.swift
@@ -191,6 +191,6 @@ extension CarouselStack {
     ) {
         self.data = data
         self.content = content
-        self._index = State(initialValue: data.startIndex)
+        self._index = State(initialValue: initialIndex ?? data.startIndex)
     }
 }


### PR DESCRIPTION
- The second initializer was ignoring the initialIndex parameter
- Always used data.startIndex instead of initialIndex ?? data.startIndex
- This caused CarouselStack to always start at index 0
- Fixes issue #82: CarouselStack initialIndex not working