### PR TITLE
Fix SizePreferenceKey reduce logic

### DIFF
--- a/Sources/Utils/PreferenceKeys/SizePreferenceKey.swift
+++ b/Sources/Utils/PreferenceKeys/SizePreferenceKey.swift
@@ -4,7 +4,9 @@ import SwiftUI
 public struct SizePreferenceKey: PreferenceKey {
     public typealias Value = CGSize
 
-    public static var defaultValue: Value = .zero
+    public static let defaultValue: Value = .zero
 
-    public static func reduce(value: inout Value, nextValue: () -> Value) { }
+    public static func reduce(value: inout Value, nextValue: () -> Value) {
+        value = CGSize(width: value.width + nextValue().width, height: value.height + nextValue().height)
+    }
 }

--- a/Sources/Utils/PreferenceKeys/SizePreferenceKey.swift
+++ b/Sources/Utils/PreferenceKeys/SizePreferenceKey.swift
@@ -7,6 +7,7 @@ public struct SizePreferenceKey: PreferenceKey {
     public static let defaultValue: Value = .zero
 
     public static func reduce(value: inout Value, nextValue: () -> Value) {
-        value = CGSize(width: value.width + nextValue().width, height: value.height + nextValue().height)
+        let next = nextValue()
+        value = CGSize(width: value.width + next.width, height: value.height + next.height)
     }
 }


### PR DESCRIPTION
I changed the reduce method to sum the width and height of CGSize values instead of leaving the value unchanged. This resolves a UI overlapping issue in `CarouselStack` when the element view is complex and the initial index is not the default.